### PR TITLE
Add shebang to cli script

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 // Import necessary packages
 import yargs from 'yargs'
 import { hideBin } from 'yargs/helpers'


### PR DESCRIPTION
Hey! I tried installing the cli script and was getting this error:

```
bin/daybridge-colors: line 1: use strict: command not found
```

I managed to get it working by adding a shebang to the first line of the cli script in `bin/daybridge-colors`.

Not tested a proper build with this change, just added the line where I think it belongs. 